### PR TITLE
Option to override table prefix & resolve size monitor type change

### DIFF
--- a/manifest.lkml
+++ b/manifest.lkml
@@ -9,3 +9,8 @@ constant: DATASET_NAME {
   value: "PROD_INSIGHTS"
   export: override_required
 }
+
+constant: TABLE_PREFIX {
+  value: "INSIGHT_"
+  export: override_optional
+}

--- a/marketplace.json
+++ b/marketplace.json
@@ -14,7 +14,7 @@
       "DATASET_NAME": {
         "label": "Monte Carlo Dataset Name"
       },
-      "DATASET_NAME": {
+      "TABLE_PREFIX": {
         "label": "Monte Carlo Table Prefix (leave blank)"
       }
     },

--- a/marketplace.json
+++ b/marketplace.json
@@ -5,7 +5,7 @@
       "image_uri": "https://files.readme.io/39894f8-small-Monte_Carlo_Logo_Primary.png",
       "tagline": "This Block provides access to the various metadata Monte Carlo collects to support a range of analytical and tracking use cases. Many of our customers today access this data to define and track SLI performance, monitor data asset usage, determine the most important (or least important) data assets, and more."
     },
-  
+
     "constants": {
       "CONNECTION_NAME": {
         "label": "Looker Connection Name",
@@ -13,6 +13,9 @@
       },
       "DATASET_NAME": {
         "label": "Monte Carlo Dataset Name"
+      },
+      "DATASET_NAME": {
+        "label": "Monte Carlo Table Prefix (leave blank)"
       }
     },
     "models": [

--- a/views/insight_cleanup_suggestions.view.lkml
+++ b/views/insight_cleanup_suggestions.view.lkml
@@ -1,5 +1,5 @@
 view: insight_cleanup_suggestions {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_CLEANUP_SUGGESTIONS"
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}CLEANUP_SUGGESTIONS"
     ;;
 
   dimension: account_id {

--- a/views/insight_custom_rules.view.lkml
+++ b/views/insight_custom_rules.view.lkml
@@ -1,5 +1,5 @@
 view: insight_custom_rules {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_CUSTOM_RULES"
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}CUSTOM_RULES"
     ;;
 
   dimension: account_id {

--- a/views/insight_dashboard_analytics.view.lkml
+++ b/views/insight_dashboard_analytics.view.lkml
@@ -1,5 +1,5 @@
 view: insight_dashboard_analytics {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_DASHBOARD_ANALYTICS"
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}DASHBOARD_ANALYTICS"
     ;;
 
   dimension: account_id {

--- a/views/insight_events.view.lkml
+++ b/views/insight_events.view.lkml
@@ -1,5 +1,5 @@
 view: insight_events {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_EVENTS"
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}EVENTS"
     ;;
 
   filter: incident_date_filter {

--- a/views/insight_incident_history.view.lkml
+++ b/views/insight_incident_history.view.lkml
@@ -1,5 +1,5 @@
 view: insight_incident_history {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_INCIDENT_HISTORY"
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}INCIDENT_HISTORY"
     ;;
 
   dimension: account_id {

--- a/views/insight_key_assets.view.lkml
+++ b/views/insight_key_assets.view.lkml
@@ -1,5 +1,5 @@
 view: insight_key_assets {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_KEY_ASSETS"
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}KEY_ASSETS"
     ;;
 
   dimension: account_id {

--- a/views/insight_monitor_issues_and_solutions.view.lkml
+++ b/views/insight_monitor_issues_and_solutions.view.lkml
@@ -1,5 +1,5 @@
 view: insight_monitor_issues_and_solutions {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_MONITOR_ISSUES_AND_SOLUTIONS"
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}MONITOR_ISSUES_AND_SOLUTIONS"
     ;;
 
   dimension: account_id {

--- a/views/insight_monitor_recom_dt_fields.view.lkml
+++ b/views/insight_monitor_recom_dt_fields.view.lkml
@@ -1,5 +1,5 @@
 view: insight_monitor_recom_dt_fields {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_MONITOR_RECOM_DT_FIELDS"
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}MONITOR_RECOM_DT_FIELDS"
     ;;
 
   dimension: account_id {

--- a/views/insight_monitor_recom_fh_tables.view.lkml
+++ b/views/insight_monitor_recom_fh_tables.view.lkml
@@ -1,5 +1,5 @@
 view: insight_monitor_recom_fh_tables {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_MONITOR_RECOM_FH_TABLES"
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}MONITOR_RECOM_FH_TABLES"
     ;;
 
   dimension: account_id {

--- a/views/insight_monitors.view.lkml
+++ b/views/insight_monitors.view.lkml
@@ -126,12 +126,23 @@ view: insight_monitors {
 
   dimension: size_monitor {
     type: yesno
-    sql: ${TABLE}."SIZE_MONITOR" ;;
+    # sql: ${TABLE}."SIZE_MONITOR" ;;
+    sql: ${volume_change_monitor} or ${unchanged_size_monitor} ;;
   }
 
   dimension: table_name {
     type: string
     sql: ${TABLE}."TABLE_NAME" ;;
+  }
+
+  dimension: volume_change_monitor {
+    type: yesno
+    sql: ${TABLE}.volume_change_monitor ;;
+  }
+
+  dimension: unchanged_size_monitor {
+    type: yesno
+    sql: ${TABLE}.unchanged_size_monitor ;;
   }
 
   dimension: is_wildcard_table {

--- a/views/insight_monitors.view.lkml
+++ b/views/insight_monitors.view.lkml
@@ -1,5 +1,5 @@
 view: insight_monitors {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_MONITORS" ;;
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}MONITORS" ;;
   drill_fields: [project_name, dataset_name, table_name, table_type, total_monitors]
 
   dimension: row_number {

--- a/views/insight_query_performance.view.lkml
+++ b/views/insight_query_performance.view.lkml
@@ -1,5 +1,5 @@
 view: insight_query_performance {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_QUERY_PERFORMANCE"
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}QUERY_PERFORMANCE"
     ;;
 
   dimension: account_id {

--- a/views/insight_query_runtime_trends.view.lkml
+++ b/views/insight_query_runtime_trends.view.lkml
@@ -1,5 +1,5 @@
 view: insight_query_runtime_trends {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_QUERY_RUNTIME_TRENDS"
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}QUERY_RUNTIME_TRENDS"
     ;;
 
   dimension: account_id {

--- a/views/insight_rca_query_change.view.lkml
+++ b/views/insight_rca_query_change.view.lkml
@@ -1,5 +1,5 @@
 view: insight_rca_query_change {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_RCA_QUERY_CHANGE"
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}RCA_QUERY_CHANGE"
     ;;
 
   dimension: account_id {

--- a/views/insight_table_read_write_stats.view.lkml
+++ b/views/insight_table_read_write_stats.view.lkml
@@ -1,5 +1,5 @@
 view: insight_table_read_write_stats {
-  sql_table_name: "@{DATASET_NAME}"."INSIGHT_TABLE_READ_WRITE_STATS"
+  sql_table_name: "@{DATASET_NAME}"."@{TABLE_PREFIX}TABLE_READ_WRITE_STATS"
     ;;
 
   dimension: account_id {


### PR DESCRIPTION
Implemented an option to override the table prefix for PROD_INSIGHTS since customers don't have the full prefix.